### PR TITLE
Pin mailcatcher to 0.8.2

### DIFF
--- a/cookbooks/matomo/attributes/default.rb
+++ b/cookbooks/matomo/attributes/default.rb
@@ -6,6 +6,8 @@ default['matomo']['mysql_password'] = 'matomo'
 default['matomo']['mysql_username'] = 'matomo'
 default['matomo']['server_name']    = 'dev.matomo.io'
 
+default['mailcatcher']['version'] = '0.8.2'
+
 default['redisio']['bin_path']        = '/usr/bin'
 default['redisio']['package_install'] = true
 default['redisio']['version']         = nil

--- a/cookbooks/matomo/recipes/webserver.rb
+++ b/cookbooks/matomo/recipes/webserver.rb
@@ -89,9 +89,29 @@ packages.each do |pkg|
   end
 end
 
+gem_package 'net-protocol' do
+  version '0.1.2'
+  package_name 'net-protocol'
+end
+
+gem_package 'net-smtp' do
+  version '0.3.0'
+  package_name 'net-smtp'
+end
+
+gem_package 'net-imap' do
+  version '0.2.2'
+  package_name 'net-imap'
+end
+
 gem_package 'sqlite3' do
   version '1.4.4'
   package_name 'sqlite3'
+end
+
+gem_package 'mini_mime' do
+  version '1.1.2'
+  package_name 'mini_mime'
 end
 
 include_recipe "chef-mailcatcher::default"


### PR DESCRIPTION
Since the `mailcatcher` update to `0.9.0` the installation is no longer possible with the default Ubuntu 18.04 `ruby 2.5`.

Pinning it to `0.8.2` (and a bunch of related dependencies) should allow it until the OS version gets updated next time.